### PR TITLE
Build Windows+PY35 and remove homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ env:
     - secure: "lzrqDJmz3bwkIyjJT4mBpTo4uRH+XPb5tr4QrgCqTI0VvsKB6ip9l/DbUG/u3RtA23EJnZNEbftIVptmxhgRBL84jhZ9PVFjh/IKVkLN3nXxHvyVqzLZ2hWHL5TL1fExZLot3mu9cehGWfNmg6JXLWhENis/ckmvjDt7EI9YHpdEpaj/u6GgPE7qzlnzWYozyTD2TcXSjVpMH5rJ5h8aorU8smEoX3acTI0p9BxcvXqQp2HSfmR8NS4KTWb2TfnBsv5jxl913CNMHLORnOYXy0Xd/PC9MEcvtLbYy8BCx1cfg1VnzwXpy2RrCXJ0K6g3xuZuPCTGe8jPxHeOiYnCBATWj+ZFLeofvcYPmjUyxzrJr99SaOKZ4m8UWROZngqQZfGGBKvs/2jpu95/cDlx4EuInwqEQXOnSi3TwBPagZM95Z2F8XNVNAUs/RY57g6cUrFoTeMkE3wSNauqoPUzSfapp5kenPfwm8w9yieVzqWTgdIMrnwsDM2oGoH9AhYFStw+ypj4G2rJpU78QdRMy+xTEI15tOi0ki11FKnjgZVLsbLROq6c92qHSutG9b0u2pZDFPD0AqdhaqsCygxKdcHnuKcc8uyPIEiHl5Nj09GaGVaW37gK/cC9lGZp7PTjSyLWXBI9O8e/8F5BZb/DuKxjqeDFQ5ZJM1gZlac8ErY="
 
 
-before install:
+before_install:
     - brew remove --force $(brew list)
 
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,20 @@ environment:
       CONDA_NPY: 111
       CONDA_PY: 34
 
+    - TARGET_ARCH: x86
+      CONDA_NPY: 110
+      CONDA_PY: 35
+    - TARGET_ARCH: x64
+      CONDA_NPY: 110
+      CONDA_PY: 35
+
+    - TARGET_ARCH: x86
+      CONDA_NPY: 111
+      CONDA_PY: 35
+    - TARGET_ARCH: x64
+      CONDA_NPY: 111
+      CONDA_PY: 35
+
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
     md5: f68a470455f92cb45d56e4a549a2161c
 
 build:
-    number: 2
-    skip: True  # [win and py35]
+    number: 3
     preserve_egg_dir: True
     entry_points:
         - fio=fiona.fio.main:main_group


### PR DESCRIPTION
Don't skip `Windows`+`Python 3.5` now that `gdal` is available. 