### PR TITLE
Bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -91,6 +91,10 @@ install:
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+if [[ $(uname) == Darwin ]]; then
+  export LDFLAGS="$LDFLAGS -headerpad_max_install_names"
+fi
+
 $PYTHON setup.py build_ext -I$PREFIX/include -L$PREFIX/lib -lgdal install --single-version-externally-managed --record record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
-{% set version = "1.6.3" %}
+{% set version = "1.6.4" %}
 
 package:
     name: fiona
     version: {{ version }}
 
 source:
-    fn: Fiona-{{ version }}.post1.tar.gz
-    url: https://pypi.python.org/packages/source/F/Fiona/Fiona-{{ version }}.post1.tar.gz
-    md5: f68a470455f92cb45d56e4a549a2161c
+    fn: fiona-{{ version }}.post1.tar.gz
+    url: https://github.com/Toblerity/Fiona/archive/{{ version }}.tar.gz
+    sha256: a84fb516e69c218a5346b3850f3f5df5bd0c8fb861dc76cc05bb4ef909be7120
 
 build:
-    number: 5
+    number: 0
     preserve_egg_dir: True
     entry_points:
         - fio=fiona.fio.main:main_group


### PR DESCRIPTION
Changes
=======

All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.

1.6.4 (2016-05-06)
------------------
- Raise ImportError if the active GDAL library version is >= 2.0 instead of
  failing unpredictably (#338, #341). Support for GDAL>=2.0 is coming in
  Fiona 1.7.