### PR TITLE
Fiona 1.7.0 (with gdal 2.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
-      conda config --set show_channel_urls true
       conda update --yes conda
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
+      conda config --set show_channel_urls true
       
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -91,9 +91,9 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels conda-forge
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
     # Workaround for Python 3.4 and x64 bug in latest conda-build.

--- a/recipe/gdal_version_win.patch
+++ b/recipe/gdal_version_win.patch
@@ -1,0 +1,11 @@
+--- setup.py	2016-06-15 13:28:44.000000000 -0300
++++ setup.py	2016-06-15 20:03:19.706422409 -0300
+@@ -79,6 +79,8 @@
+     index = sys.argv.index('--gdalversion')
+     sys.argv.pop(index)
+     gdalversion = sys.argv.pop(index)
++else:
++   gdalversion = '2.1.0'
+ 
+ # Extend distutil's sdist command to generate C extension sources from
+ # both `ogrext`.pyx` and `ogrext2.pyx` for GDAL 1.x and 2.x.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,6 @@ test:
         - fiona.fio
     commands:
         - fio --help
-        - conda inspect linkages fiona --name _test  # [linux]
     requires:
         - nose
     files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.4" %}
+{% set version = "1.7.0" %}
 
 package:
     name: fiona
@@ -6,11 +6,11 @@ package:
 
 source:
     fn: fiona-{{ version }}.post1.tar.gz
-    url: https://github.com/Toblerity/Fiona/archive/{{ version }}.tar.gz
-    sha256: a84fb516e69c218a5346b3850f3f5df5bd0c8fb861dc76cc05bb4ef909be7120
+    url: https://github.com/Toblerity/Fiona/archive/{{ version }}.post2.tar.gz
+    sha256: 5eb68355b72f69f93a6c9948c0a6dc92b14408aa0d7c0ec48f097fcf17f70ee4
 
 build:
-    number: 1
+    number: 0
     preserve_egg_dir: True
     entry_points:
         - fio=fiona.fio.main:main_group
@@ -21,12 +21,12 @@ requirements:
         - cython
         - setuptools
         - numpy x.x
-        - gdal 1.11.4
+        - gdal >=2
     run:
         - python
         - setuptools
         - numpy x.x
-        - gdal 1.11.4
+        - gdal >=2
         - cligj
         - munch
         - click-plugins

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ source:
     fn: fiona-{{ version }}.post1.tar.gz
     url: https://github.com/Toblerity/Fiona/archive/{{ version }}.post2.tar.gz
     sha256: 5eb68355b72f69f93a6c9948c0a6dc92b14408aa0d7c0ec48f097fcf17f70ee4
+    patches:
+        - gdal_version_win.patch  # [win]
 
 build:
     number: 0
@@ -21,12 +23,12 @@ requirements:
         - cython
         - setuptools
         - numpy x.x
-        - gdal >=2
+        - gdal >=2.*
     run:
         - python
         - setuptools
         - numpy x.x
-        - gdal >=2
+        - gdal >=2.*
         - cligj
         - munch
         - click-plugins


### PR DESCRIPTION
Closes #14 

Unpin once we have `fiona` with `gdal` merged:

- [ ] `rasterio`
- [ ] `pynio`
- [ ] `geopandas`


```
Changes
=======

All issue numbers are relative to https://github.com/Toblerity/Fiona/issues.

1.7.0post2 (2016-06-15)
-----------------------

Packaging: define extension modules for 'clean' and 'config' targets (#363).

1.7.0post1 (2016-06-15)
-----------------------

Packaging: No files are copied for the 'clean' setup target (#361, #362).

1.7.0 (2016-06-14)
------------------

The C extension modules in this library can now be built and used with either
a 1.x or 2.x release of the GDAL library. Big thanks to René Buffat for
leading this effort.

Refactoring:

- The `ogrext1.pyx` and `ogrext2.pyx` files now use separate
  C APIs defined in `ogrext1.pxd` and `ogrex2.pxd`. The other extension
  modules have been refactored so that they do not depend on either of these
  modules and use subsets of the GDAL/OGR API compatible with both GDAL 1.x and
  2.x (#359).

Packaging:

- Source distributions now contain two different sources for the
  `ogrext` extension module. The `ogrext1.c` file will be used with GDAL 1.x
  and the `ogrext2.c` file will be used with GDAL 2.x.

1.7b2 (2016-06-13)
------------------

- New feature: enhancement of the `--layer` option for fio-cat and fio-dump
  to allow separate layers of one or more multi-layer input files to be
  selected (#349).

1.7b1 (2016-06-10)
------------------

- New feature: support for GDAL version 2+ (#259).
- New feature: a new fio-calc CLI command (#273).
- New feature: `--layer` options for fio-info (#316) and fio-load (#299).
- New feature: a `--no-parse` option for fio-collect that lets a careful user
  avoid extra JSON serialization and deserialization (#306).
- Bug fix: `+wktext` is now preserved when serializing CRS from WKT to PROJ.4
  dicts (#352).
- Bug fix: a small memory leak when opening a collection has been fixed (#337).
- Bug fix: internal unicode errors now result in a log message and a 
  `UnicodeError` exception, not a `TypeError` (#356).
```