### PR TITLE
Pin gdal 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ install:
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
       conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
-      conda config --set show_channel_urls true
       
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -91,9 +91,9 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels conda-forge
-    - cmd: conda config --set show_channel_urls true
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
     # Workaround for Python 3.4 and x64 bug in latest conda-build.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
         - gdal_version.patch
 
 build:
-    number: 0
+    number: 1
     preserve_egg_dir: True
     entry_points:
         - fio=fiona.fio.main:main_group
@@ -23,12 +23,12 @@ requirements:
         - cython
         - setuptools
         - numpy x.x
-        - gdal >=2.*
+        - gdal 2.1.*
     run:
         - python
         - setuptools
         - numpy x.x
-        - gdal >=2.*
+        - gdal 2.1.*
         - cligj
         - munch
         - click-plugins


### PR DESCRIPTION
Prevents from wrongly downloading `gdal` from the default channel.