### PR TITLE
Add inspect linkages test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,8 +38,6 @@ test:
     imports:
         - fiona
         - fiona.fio
-    commands:
-        - fio --help
     requires:
         - nose
     files:
@@ -47,6 +45,9 @@ test:
         - test.dbf
         - test.shp
         - test.shx
+    commands:
+        - fio --help
+        - conda inspect linkages -n _test fiona  # [linux]
 
 about:
     home: http://github.com/Toblerity/Fiona


### PR DESCRIPTION
Ideally we should always run this test when there is a `cython` extension.