### PR TITLE
Update to 1.7.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,6 @@
 
 environment:
 
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script intepreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -103,7 +98,6 @@ install:
     - cmd: conda config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
@@ -111,6 +105,6 @@ install:
 build: off
 
 test_script:
-    - "%CMD_IN_ENV% conda build recipe --quiet"
+    - conda build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -24,16 +24,30 @@ show_channel_urls: true
 CONDARC
 )
 
+# In order for the conda-build process in the container to write to the mounted
+# volumes, we need to run with the same id as the host machine, which is
+# normally the owner of the mounted volumes, or at least has write permission
+HOST_USER_ID=$(id -u)
+# Check if docker-machine is being used (normally on OSX) and get the uid from
+# the VM
+if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
+    HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
+fi
+
 rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
 
 cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
+                        -e HOST_USER_ID="${HOST_USER_ID}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit 1
 
+set -e
+set +x
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
+set -x
 export PYTHONUNBUFFERED=1
 
 echo "$config" > ~/.condarc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.7.5" %}
+{% set version = "1.7.6" %}
 
 package:
   name: fiona
@@ -7,7 +7,7 @@ package:
 source:
   fn: fiona-{{ version }}.tar.gz
   url: https://github.com/Toblerity/Fiona/archive/{{ version }}.tar.gz
-  sha256: 98cfd0b04af92d08ae9558d61d4e21e681cfba56d8b7f0d428567c91942c0ca0
+  sha256: 00f4cd94bc3e095e5c576dd42184722d5f99e061fce9b992f77f2fbd8afeb76e
 
 build:
   number: 0
@@ -31,6 +31,8 @@ requirements:
     - munch
     - click-plugins
     - six
+    - enum34  # [py27]
+    - shapely
 
 test:
   source_files:
@@ -45,6 +47,8 @@ test:
     - test_data
   commands:
     - fio --help
+    - fio ls test_data/test.shp
+    - fio info test_data/test.shp
     - conda inspect linkages -p $PREFIX fiona  # [not win]
     - conda inspect objects -p $PREFIX fiona  # [osx]
 

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,8 +1,4 @@
-# OS X is broken.
-# See: https://travis-ci.org/conda-forge/fiona-feedstock/jobs/198841996
-if [[ $(uname) == Linux ]]; then
 mkdir -p tests/tests/data
 cp test_data/coutwildrnp.zip tests/tests/data
 
 nosetests --exclude test_filter_vsi --exclude test_geopackage --exclude test_write_mismatch tests
-fi


### PR DESCRIPTION
```
1.7.6 (2017-04-26)
------------------

Bug fixes:

- Fall back to `share/proj` for PROJ_LIB (#440).
- Replace every call to `OSRDestroySpatialReference()` with `OSRRelease()`,
  fixing the GPKG driver crasher reported in #441 (#443).
- Add a `DriverIOError` derived from `IOError` to use for driver-specific
  errors such as the GeoJSON driver's refusal to overwrite existing files.
  Also we now ensure that when this error is raised by `fiona.open()` any
  created read or write session is deleted, this eliminates spurious 
  exceptions on teardown of broken `Collection` objects (#437, #444).
```