### PR TITLE
Update 1.7.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.7.9" %}
+{% set version = "1.7.10" %}
 
 package:
   name: fiona
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/F/Fiona/Fiona-{{ version }}.tar.gz
-  sha256: 91bb71b744a7444c3d96472158b74af1569ec2bc934737397658b968dd7dadba
+  sha256: 564d2f3485547a6b45e3e322249f02c1cc5a651890a27b3b5bab596a64ae0b67
 
 build:
-  number: 1
+  number: 0
   preserve_egg_dir: True
   entry_points:
     - fio=fiona.fio.main:main_group


### PR DESCRIPTION
```
1.7.10 (2017-10-26)
-------------------

Bug fixes:

- An extraneous printed line from the ``rio cat --layers`` validator has been
  removed (#478).

Packaging:

- Official OS X and Manylinux1 wheels (on PyPI) for this release will be
  compatible with Shapely 1.6.2 and Rasterio 1.0a10 wheels.
```