### PR TITLE
Bump build number, current version fails if icu is too new

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: fa31dfe8855b9cd0b128b47a4df558f1b8eda90d2181bff1dd9854e5556efb3e
 
 build:
-  number: 3
+  number: 4
   skip: True  # [win and vc<14]
   entry_points:
     - fio = fiona.fio.main:main_group


### PR DESCRIPTION
```
conda create -y --quiet --override-channels --channel iuc --channel conda-forge --channel bioconda --channel defaults --name __fiona@1.8.6 fiona=1.8.6
Collecting package metadata: ...working... done
Solving environment: ...working... done

  environment location: /tmp/tmpDYqbuY/tmpDWh0aA/tmpSOUDIV/database/tool_dependenciesCAafuD/_conda/envs/__fiona@1.8.6

  added / updated specs:
    - fiona=1.8.6

The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    attrs-19.1.0               |             py_0          32 KB  conda-forge
    boost-cpp-1.70.0           |       h8e57a91_2        21.1 MB  conda-forge
    cairo-1.16.0               |    hfb77d84_1002         1.5 MB  conda-forge
    cfitsio-3.470              |       hb60a0a2_1         1.4 MB  conda-forge
    click-7.0                  |             py_0          61 KB  conda-forge
    click-plugins-1.1.1        |             py_0           9 KB  conda-forge
    cligj-0.5.0                |             py_0           8 KB  conda-forge
    expat-2.2.5                |    he1b5a44_1003         191 KB  conda-forge
    fiona-1.8.6                |   py37hf242f0b_3         1.1 MB  conda-forge
    fontconfig-2.13.1          |    h86ecdb6_1001         340 KB  conda-forge
    freetype-2.10.0            |       he983fc9_0         885 KB  conda-forge
    freexl-1.0.5               |    h14c3975_1002          43 KB  conda-forge
    gdal-2.4.2                 |   py37h5f563d9_2         1.3 MB  conda-forge
    geos-3.7.2                 |       he1b5a44_1         872 KB  conda-forge
    geotiff-1.5.1              |       h560c3f3_2         279 KB  conda-forge
    gettext-0.19.8.1           |    hc5be6a0_1002         3.6 MB  conda-forge
    giflib-5.1.7               |       h516909a_1         455 KB  conda-forge
    glib-2.58.3                |    h6f030ca_1002         3.3 MB  conda-forge
    hdf4-4.2.13                |    h9a582f1_1002         952 KB  conda-forge
    hdf5-1.10.5                |nompi_h3c11f04_1100         5.2 MB  conda-forge
    icu-64.2                   |       he1b5a44_0        12.6 MB  conda-forge
    jpeg-9c                    |    h14c3975_1001         251 KB  conda-forge
    json-c-0.13.1              |    h14c3975_1001          71 KB  conda-forge
    kealib-1.4.10              |    h58c409b_1005         173 KB  conda-forge
    libblas-3.8.0              |      10_openblas           6 KB  conda-forge
    libcblas-3.8.0             |      10_openblas           6 KB  conda-forge
    libdap4-3.19.1             |    hd48c02d_1000         1.6 MB  conda-forge
    libffi-3.2.1               |    he1b5a44_1006          46 KB  conda-forge
    libgdal-2.4.2              |       h0845e09_2        18.7 MB  conda-forge
    libgfortran-ng-7.3.0       |       hdf63c60_0         1.3 MB
    libiconv-1.15              |    h516909a_1005         2.0 MB  conda-forge
    libkml-1.3.0               |    h4fcabce_1010         643 KB  conda-forge
    liblapack-3.8.0            |      10_openblas           6 KB  conda-forge
    libnetcdf-4.6.2            |    h056eaf5_1002         1.3 MB  conda-forge
    libopenblas-0.3.6          |       h6e990d7_4         7.7 MB  conda-forge
    libpng-1.6.37              |       hed695b0_0         343 KB  conda-forge
    libpq-11.4                 |       hd9ab2ff_3         2.5 MB  conda-forge
    libspatialite-4.3.0a       |    he1bb1e1_1029         3.1 MB  conda-forge
    libtiff-4.0.10             |    h57b8799_1003         587 KB  conda-forge
    libuuid-2.32.1             |    h14c3975_1000          26 KB  conda-forge
    libxcb-1.13                |    h14c3975_1002         396 KB  conda-forge
    libxml2-2.9.9              |       hee79883_2         1.3 MB  conda-forge
    lz4-c-1.8.3                |    he1b5a44_1001         187 KB  conda-forge
    munch-2.3.2                |             py_0           8 KB  conda-forge
    numpy-1.16.4               |   py37h95a1406_0         4.3 MB  conda-forge
    openblas-0.3.6             |       h6e990d7_4         8.2 MB  conda-forge
    openjpeg-2.3.1             |       h58a6597_0         470 KB  conda-forge
    pcre-8.41                  |    hf484d3e_1003         249 KB  conda-forge
    pip-19.1.1                 |           py37_0         1.8 MB  conda-forge
    pixman-0.38.0              |    h516909a_1003         594 KB  conda-forge
    poppler-0.67.0             |       ha967d66_7         8.9 MB  conda-forge
    poppler-data-0.4.9         |                1         3.4 MB  conda-forge
    postgresql-11.4            |       hc63931a_3         4.8 MB  conda-forge
    proj4-6.1.0                |       he751ad9_2         9.4 MB  conda-forge
    pthread-stubs-0.4          |    h14c3975_1001           5 KB  conda-forge
    python-3.7.3               |       h33d41f4_1        36.0 MB  conda-forge
    readline-8.0               |       hf8c457e_0         441 KB  conda-forge
    setuptools-41.0.1          |           py37_0         616 KB  conda-forge
    shapely-1.6.4              |py37hec07ddf_1006         339 KB  conda-forge
    six-1.12.0                 |        py37_1000          22 KB  conda-forge
    sqlite-3.29.0              |       hcee41ef_0         2.0 MB  conda-forge
    tzcode-2019a               |    h516909a_1002         429 KB  conda-forge
    wheel-0.33.4               |           py37_0          34 KB  conda-forge
    xerces-c-3.2.2             |    h8412b87_1004         1.7 MB  conda-forge
    xorg-kbproto-1.0.7         |    h14c3975_1002          26 KB  conda-forge
    xorg-libice-1.0.10         |       h516909a_0          57 KB  conda-forge
    xorg-libsm-1.2.3           |    h84519dc_1000          25 KB  conda-forge
    xorg-libx11-1.6.8          |       h516909a_0         907 KB  conda-forge
    xorg-libxau-1.0.9          |       h14c3975_0          13 KB  conda-forge
    xorg-libxdmcp-1.1.3        |       h516909a_0          18 KB  conda-forge
    xorg-libxext-1.3.4         |       h516909a_0          51 KB  conda-forge
    xorg-libxrender-0.9.10     |    h516909a_1002          31 KB  conda-forge
    xorg-renderproto-0.11.1    |    h14c3975_1002           8 KB  conda-forge
    xorg-xextproto-7.3.0       |    h14c3975_1002          27 KB  conda-forge
    xorg-xproto-7.0.31         |    h14c3975_1007          72 KB  conda-forge
    zstd-1.4.0                 |       h3b9ef0a_0         928 KB  conda-forge
    ------------------------------------------------------------
                                           Total:       182.9 MB

The following NEW packages will be INSTALLED:

  _libgcc_mutex      pkgs/main/linux-64::_libgcc_mutex-0.1-main
  attrs              conda-forge/noarch::attrs-19.1.0-py_0
  boost-cpp          conda-forge/linux-64::boost-cpp-1.70.0-h8e57a91_2
  bzip2              conda-forge/linux-64::bzip2-1.0.8-h516909a_0
  ca-certificates    conda-forge/linux-64::ca-certificates-2019.6.16-hecc5488_0
  cairo              conda-forge/linux-64::cairo-1.16.0-hfb77d84_1002
  certifi            conda-forge/linux-64::certifi-2019.6.16-py37_1
  cfitsio            conda-forge/linux-64::cfitsio-3.470-hb60a0a2_1
  click              conda-forge/noarch::click-7.0-py_0
  click-plugins      conda-forge/noarch::click-plugins-1.1.1-py_0
  cligj              conda-forge/noarch::cligj-0.5.0-py_0
  curl               conda-forge/linux-64::curl-7.65.3-hf8cf82a_0
  expat              conda-forge/linux-64::expat-2.2.5-he1b5a44_1003
  fiona              conda-forge/linux-64::fiona-1.8.6-py37hf242f0b_3
  fontconfig         conda-forge/linux-64::fontconfig-2.13.1-h86ecdb6_1001
  freetype           conda-forge/linux-64::freetype-2.10.0-he983fc9_0
  freexl             conda-forge/linux-64::freexl-1.0.5-h14c3975_1002
  gdal               conda-forge/linux-64::gdal-2.4.2-py37h5f563d9_2
  geos               conda-forge/linux-64::geos-3.7.2-he1b5a44_1
  geotiff            conda-forge/linux-64::geotiff-1.5.1-h560c3f3_2
  gettext            conda-forge/linux-64::gettext-0.19.8.1-hc5be6a0_1002
  giflib             conda-forge/linux-64::giflib-5.1.7-h516909a_1
  glib               conda-forge/linux-64::glib-2.58.3-h6f030ca_1002
  hdf4               conda-forge/linux-64::hdf4-4.2.13-h9a582f1_1002
  hdf5               conda-forge/linux-64::hdf5-1.10.5-nompi_h3c11f04_1100
  icu                conda-forge/linux-64::icu-64.2-he1b5a44_0
  jpeg               conda-forge/linux-64::jpeg-9c-h14c3975_1001
  json-c             conda-forge/linux-64::json-c-0.13.1-h14c3975_1001
  kealib             conda-forge/linux-64::kealib-1.4.10-h58c409b_1005
  krb5               conda-forge/linux-64::krb5-1.16.3-h05b26f9_1001
  libblas            conda-forge/linux-64::libblas-3.8.0-10_openblas
  libcblas           conda-forge/linux-64::libcblas-3.8.0-10_openblas
  libcurl            conda-forge/linux-64::libcurl-7.65.3-hda55be3_0
  libdap4            conda-forge/linux-64::libdap4-3.19.1-hd48c02d_1000
  libedit            conda-forge/linux-64::libedit-3.1.20170329-hf8c457e_1001
  libffi             conda-forge/linux-64::libffi-3.2.1-he1b5a44_1006
  libgcc-ng          pkgs/main/linux-64::libgcc-ng-9.1.0-hdf63c60_0
  libgdal            conda-forge/linux-64::libgdal-2.4.2-h0845e09_2
  libgfortran-ng     pkgs/main/linux-64::libgfortran-ng-7.3.0-hdf63c60_0
  libiconv           conda-forge/linux-64::libiconv-1.15-h516909a_1005
  libkml             conda-forge/linux-64::libkml-1.3.0-h4fcabce_1010
  liblapack          conda-forge/linux-64::liblapack-3.8.0-10_openblas
  libnetcdf          conda-forge/linux-64::libnetcdf-4.6.2-h056eaf5_1002
  libopenblas        conda-forge/linux-64::libopenblas-0.3.6-h6e990d7_4
  libpng             conda-forge/linux-64::libpng-1.6.37-hed695b0_0
  libpq              conda-forge/linux-64::libpq-11.4-hd9ab2ff_3
  libspatialite      conda-forge/linux-64::libspatialite-4.3.0a-he1bb1e1_1029
  libssh2            conda-forge/linux-64::libssh2-1.8.2-h22169c7_2
  libstdcxx-ng       pkgs/main/linux-64::libstdcxx-ng-9.1.0-hdf63c60_0
  libtiff            conda-forge/linux-64::libtiff-4.0.10-h57b8799_1003
  libuuid            conda-forge/linux-64::libuuid-2.32.1-h14c3975_1000
  libxcb             conda-forge/linux-64::libxcb-1.13-h14c3975_1002
  libxml2            conda-forge/linux-64::libxml2-2.9.9-hee79883_2
  lz4-c              conda-forge/linux-64::lz4-c-1.8.3-he1b5a44_1001
  munch              conda-forge/noarch::munch-2.3.2-py_0
  ncurses            conda-forge/linux-64::ncurses-6.1-hf484d3e_1002
  numpy              conda-forge/linux-64::numpy-1.16.4-py37h95a1406_0
  openblas           conda-forge/linux-64::openblas-0.3.6-h6e990d7_4
  openjpeg           conda-forge/linux-64::openjpeg-2.3.1-h58a6597_0
  openssl            conda-forge/linux-64::openssl-1.1.1c-h516909a_0
  pcre               conda-forge/linux-64::pcre-8.41-hf484d3e_1003
  pip                conda-forge/linux-64::pip-19.1.1-py37_0
  pixman             conda-forge/linux-64::pixman-0.38.0-h516909a_1003
  poppler            conda-forge/linux-64::poppler-0.67.0-ha967d66_7
  poppler-data       conda-forge/noarch::poppler-data-0.4.9-1
  postgresql         conda-forge/linux-64::postgresql-11.4-hc63931a_3
  proj4              conda-forge/linux-64::proj4-6.1.0-he751ad9_2
  pthread-stubs      conda-forge/linux-64::pthread-stubs-0.4-h14c3975_1001
  python             conda-forge/linux-64::python-3.7.3-h33d41f4_1
  readline           conda-forge/linux-64::readline-8.0-hf8c457e_0
  setuptools         conda-forge/linux-64::setuptools-41.0.1-py37_0
  shapely            conda-forge/linux-64::shapely-1.6.4-py37hec07ddf_1006
  six                conda-forge/linux-64::six-1.12.0-py37_1000
  sqlite             conda-forge/linux-64::sqlite-3.29.0-hcee41ef_0
  tk                 conda-forge/linux-64::tk-8.6.9-hed695b0_1002
  tzcode             conda-forge/linux-64::tzcode-2019a-h516909a_1002
  wheel              conda-forge/linux-64::wheel-0.33.4-py37_0
  xerces-c           conda-forge/linux-64::xerces-c-3.2.2-h8412b87_1004
  xorg-kbproto       conda-forge/linux-64::xorg-kbproto-1.0.7-h14c3975_1002
  xorg-libice        conda-forge/linux-64::xorg-libice-1.0.10-h516909a_0
  xorg-libsm         conda-forge/linux-64::xorg-libsm-1.2.3-h84519dc_1000
  xorg-libx11        conda-forge/linux-64::xorg-libx11-1.6.8-h516909a_0
  xorg-libxau        conda-forge/linux-64::xorg-libxau-1.0.9-h14c3975_0
  xorg-libxdmcp      conda-forge/linux-64::xorg-libxdmcp-1.1.3-h516909a_0
  xorg-libxext       conda-forge/linux-64::xorg-libxext-1.3.4-h516909a_0
  xorg-libxrender    conda-forge/linux-64::xorg-libxrender-0.9.10-h516909a_1002
  xorg-renderproto   conda-forge/linux-64::xorg-renderproto-0.11.1-h14c3975_1002
  xorg-xextproto     conda-forge/linux-64::xorg-xextproto-7.3.0-h14c3975_1002
  xorg-xproto        conda-forge/linux-64::xorg-xproto-7.0.31-h14c3975_1007
  xz                 conda-forge/linux-64::xz-5.2.4-h14c3975_1001
  zlib               conda-forge/linux-64::zlib-1.2.11-h516909a_1005
  zstd               conda-forge/linux-64::zstd-1.4.0-h3b9ef0a_0
```

but then fails at runtime with
```
File "<string>", line 1, in <module>
  File "/tmp/tmpDYqbuY/tmpDWh0aA/tmpSOUDIV/database/tool_dependenciesCAafuD/_conda/envs/__fiona@1.8.6/lib/python3.7/site-packages/fiona/__init__.py", line 83, in <module>
    from fiona.collection import BytesCollection, Collection
  File "/tmp/tmpDYqbuY/tmpDWh0aA/tmpSOUDIV/database/tool_dependenciesCAafuD/_conda/envs/__fiona@1.8.6/lib/python3.7/site-packages/fiona/collection.py", line 9, in <module>
    from fiona.ogrext import Iterator, ItemsIterator, KeysIterator
ImportError: libicui18n.so.58: cannot open shared object file: No such file or directory
]

```
I'm hoping a bump is sufficient here.


Checklist
* [ ] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.