### PR TITLE
re-enable windows test, bump build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - 0002-add-OpenFileGDB-extension.patch
 
 build:
-  number: 4
+  number: 5
   skip: true  # [win and vc<14]
   script_env:
     - GDAL_ENABLE_DEPRECATED_DRIVER_GTM=YES

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -3,5 +3,4 @@ xcopy test_data\coutwildrnp.zip tests\data /s /e /y || exit 1
 xcopy test_data\coutwildrnp.tar tests\data /s /e /y || exit 1
 xcopy test_data\coutwildrnp.json tests\data /s /e /y || exit 1
 
-:: The tests are finishing but it hangs at the end :-/
-REM pytest -s -rxs -v -k "not (test_fio_ls_single_layer or test_directory or test_directory_trailing_slash or test_options or test_transaction or test_no_append_driver_cannot_append[PCIDSK])" tests
+%PYTHON% -m pytest -s -rxs -v -m "not wheel" -k "not (test_fio_ls_single_layer or test_directory or test_directory_trailing_slash or test_options or test_transaction or test_no_append_driver_cannot_append[PCIDSK])" tests


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Picks up where #193 left off, re-enabling the windows tests.